### PR TITLE
Update mean/max/sum/prod for tch-rs 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ tch-bindings = ["tch"]
 
 [dependencies]
 thiserror = "1.0"
-tch = { version = "0.3", optional = true }
+tch = { version = "0.5", optional = true }

--- a/src/backend/torch.rs
+++ b/src/backend/torch.rs
@@ -25,11 +25,11 @@ impl Backend for Tensor {
 
         for &axis in axes.iter().rev() {
             output = match operation {
-                Operation::Min => output.min2(axis as i64, false).0,
-                Operation::Max => output.max2(axis as i64, false).0,
-                Operation::Sum => output.sum1(&[axis as i64], false, output.kind()),
-                Operation::Mean => output.mean1(&[axis as i64], false, output.kind()),
-                Operation::Prod => output.prod1(axis as i64, false, output.kind()),
+                Operation::Min => output.min_dim(axis as i64, false).0,
+                Operation::Max => output.max_dim(axis as i64, false).0,
+                Operation::Sum => output.sum_dim_intlist(&[axis as i64], false, output.kind()),
+                Operation::Mean => output.mean_dim(&[axis as i64], false, output.kind()),
+                Operation::Prod => output.prod_dim_int(axis as i64, false, output.kind()),
             };
         }
 


### PR DESCRIPTION
Hi!

Thanks for a great project, and it's very useful to have it in the Rust ecosystem.

I was trying to build a project with both tch-rs 0.5 and einops, and found that it wouldn't compile because of some recent changes to tch-rs.

I looked for renamed functions and updated the tch-rs version used, and it now seems to work. I haven't been able to run the tests because of the way that tch-rs was included in the crate, but a small executable requiring both einops and tch-rs works if I provide this version locally (with path = ../einops).

Thanks again,

Daniel